### PR TITLE
Feat: Extension, Add support for secondary or 'auxiliary' sidebar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,10 @@
 # Change Log
 
+### 1.0.8
+* Add support for new secondary sidebar.
+
 ### 1.0.7
-* Add "extensionKind" to package.json
+* Add "extensionKind" to package.json.
 
 ### 1.0.6
 * Add commands so the user can toggle the hide options for the local environment.

--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ Same thing as above, except for the bottom panel (output, terminal, etc. are con
 ## Settings
 
 * `autoHide.autoHideSideBar`: Hide the side bar when the user clicks into a text editor. [boolean, default: `true`]
+* `autoHide.autoHideSecondarySideBar`: Hide the secondary(aux) side bar when the user clicks into a text editor. [boolean, default: `false`].
 * `autoHide.autoHidePanel`: Hide the panel (output, terminal, etc.) when the user clicks into a text editor. [boolean, default: `true`]
 * `autoHide.sideBarDelay`: How long to wait before hiding the side bar. A delay prevents text from being selected. A longer delay allows the horizontal scroll to adjust to the change in selection before the side bar hiding causes the horizontal scroll to adjust, avoiding conflicts. [number, default: `450`]
 * `autoHide.panelDelay`: How long to wait before hiding the panel. Same as for the side bar when the panel is on the side.  If the panel is on the bottom, there is no need for delay. [number, default: `300`]
@@ -27,6 +28,7 @@ Same thing as above, except for the bottom panel (output, terminal, etc. are con
 ## Commands
 
 * `autoHide.toggleHideSideBar`: Toggle `autoHide.autoHideSideBar` setting for current workspace. Use this command to pin/unpin the side bar.
+* `autoHide.toggleHideSideBar`: Toggle `autoHide.toggleHideSecondarySideBar` setting for current workspace. Use this command to pin/unpin the secondary side bar.
 * `autoHide.toggleHidePanel`: Toggle `autoHide.autoHidePanel` setting for current workspace. Use this command to pin/unpin the panel.
 
 ## Developing

--- a/package.json
+++ b/package.json
@@ -41,6 +41,11 @@
                     "default": true,
                     "description": "Hide the side bar when the user clicks into a text editor."
                 },
+                "autoHide.autoHideSecondarySideBar": {
+                    "type": "boolean",
+                    "default": false,
+                    "description": "Hide the secondary side bar when the user clicks into a text editor."
+                },
                 "autoHide.autoHidePanel": {
                     "type": "boolean",
                     "default": true,
@@ -50,6 +55,11 @@
                     "type": "number",
                     "default": 450,
                     "description": "How long to wait before hiding the side bar. A delay prevents text from being selected. A longer delay allows the horizontal scroll to adjust to the change in selection before the side bar hiding causes the horizontal scroll to adjust, avoiding conflicts."
+                },
+                "autoHide.secondarySideBarDelay": {
+                    "type": "number",
+                    "default": 450,
+                    "description": "How long to wait before hiding the secondary side bar. A delay prevents text from being selected. A longer delay allows the horizontal scroll to adjust to the change in selection before the secondary side bar hiding causes the horizontal scroll to adjust, avoiding conflicts."
                 },
                 "autoHide.panelDelay": {
                     "type": "number",
@@ -68,6 +78,11 @@
                 "command": "autoHide.toggleHideSideBar",
                 "category": "Auto Hide",
                 "title": "Toggle Auto Hide Side Bar for Current Workspace"
+            },
+            {
+                "command": "autoHide.toggleHideSecondarySideBar",
+                "category": "Auto Hide",
+                "title": "Toggle Auto Hide Secondary Side Bar for Current Workspace"
             },
             {
                 "command": "autoHide.toggleHidePanel",

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -7,6 +7,7 @@ export function activate(context: vscode.ExtensionContext) {
     if (vscode.workspace.getConfiguration("autoHide").hideOnOpen) {
         vscode.commands.executeCommand("workbench.action.closePanel");
         vscode.commands.executeCommand("workbench.action.closeSidebar");
+        vscode.commands.executeCommand("workbench.action.closeAuxiliaryBar");
     };
 
     vscode.window.onDidChangeTextEditorSelection(selection => {
@@ -31,6 +32,12 @@ export function activate(context: vscode.ExtensionContext) {
                     vscode.commands.executeCommand("workbench.action.closeSidebar");
                 }
             }, config.sideBarDelay);
+
+            setTimeout(function() {
+                if (config.autoHideSecondarySideBar) {
+                    vscode.commands.executeCommand("workbench.action.closeAuxiliaryBar");
+                }
+            }, config.secondarySideBarDelay);
         };
     });
 
@@ -38,12 +45,20 @@ export function activate(context: vscode.ExtensionContext) {
         vscode.commands.registerCommand("autoHide.toggleHidePanel", async() => {
             let config = vscode.workspace.getConfiguration("autoHide");
             await config.update("autoHidePanel", !config.autoHidePanel, vscode.ConfigurationTarget.Workspace);
-        }));
+        })
+    );
     context.subscriptions.push(
         vscode.commands.registerCommand("autoHide.toggleHideSideBar", async() => {
             let config = vscode.workspace.getConfiguration("autoHide");
             await config.update("autoHideSideBar", !config.autoHideSideBar, vscode.ConfigurationTarget.Workspace);
-        }));
+        })
+    );
+    context.subscriptions.push(
+        vscode.commands.registerCommand("autoHide.toggleHideSecondarySideBar", async() => {
+            let config = vscode.workspace.getConfiguration("autoHide");
+            await config.update("autoHideSecondarySideBar", !config.autoHideSecondarySideBar, vscode.ConfigurationTarget.Workspace);
+        })
+    );
 }
 
 export function deactivate() {}


### PR DESCRIPTION
Mindless copy and paste (not a JS person), would appreciate a version bump.

Feel free to make this a default true if you want, Don't know how important backwards usability is here.

Cheers for the extension :-)