### PR TITLE
added `autoHideReferences` option to also close References search

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ Same thing as above, except for the bottom panel (output, terminal, etc. are con
 
 * `autoHide.autoHideSideBar`: Hide the side bar when the user clicks into a text editor. [boolean, default: `true`]
 * `autoHide.autoHidePanel`: Hide the panel (output, terminal, etc.) when the user clicks into a text editor. [boolean, default: `true`]
+* `autoHide.autoHideReferences`: Hide the References panel (`Go to References`) when the user clicks into a text editor. [boolean, default: `true`]
 * `autoHide.sideBarDelay`: How long to wait before hiding the side bar. A delay prevents text from being selected. A longer delay allows the horizontal scroll to adjust to the change in selection before the side bar hiding causes the horizontal scroll to adjust, avoiding conflicts. [number, default: `450`]
 * `autoHide.panelDelay`: How long to wait before hiding the panel. Same as for the side bar when the panel is on the side.  If the panel is on the bottom, there is no need for delay. [number, default: `300`]
 * `autoHide.hideOnOpen`: Hide side bar and panel when VSCode first opens. [boolean, default: `true`]

--- a/package.json
+++ b/package.json
@@ -46,6 +46,11 @@
                     "default": true,
                     "description": "Hide the panel (output, terminal, etc.) when the user clicks into a text editor."
                 },
+                "autoHide.autoHideReferences": {
+                    "type": "boolean",
+                    "default": true,
+                    "description": "Hide the References panel (`Go to References`) when the user clicks into a text editor."
+                },
                 "autoHide.sideBarDelay": {
                     "type": "number",
                     "default": 450,

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -20,6 +20,10 @@ export function activate(context: vscode.ExtensionContext) {
             || !pathIsFile) {                                     // The debug window editor
             return;
         } else {
+            if (config.autoHideReferences) {
+                vscode.commands.executeCommand("closeReferenceSearch");
+            }
+
             setTimeout(function() {
                 if (config.autoHidePanel) {
                     vscode.commands.executeCommand("workbench.action.closePanel");


### PR DESCRIPTION
added `autoHideReferences` to also close References search i.e. [this panel](https://code.visualstudio.com/docs/editor/editingevolved#_peek).