### PR TITLE
Hide panels by settings on start

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,8 @@
 
 ### 1.0.9
 
-* Hide panels by settings on start.
+* Automatic hiding of bars and panels when the window is opened works based on "autoHide.hideOnOpen" and their individual options instead of just "autoHide.hideOnOpen".
+* "autoHide.hideOnOpen" option defaults to false
 
 ### 1.0.8
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change Log
 
+### 1.0.9
+
+* Hide panels by settings on start.
+
 ### 1.0.8
 
 * user submitted PRs.  I cant remember what they do.  Please help if you submitted them.

--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
                 },
                 "autoHide.hideOnOpen": {
                     "type": "boolean",
-                    "default": true,
+                    "default": false,
                     "description": "Hide side bar and panel when VSCode first opens."
                 }
             }

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "vscode-autohide",
     "displayName": "Auto Hide",
     "description": "A tool to autohide the sidebar and terminal panel.",
-    "version": "1.0.8",
+    "version": "1.0.9",
     "publisher": "sirmspencer",
     "repository": {
         "url": "https://github.com/sirmspencer/vscode-autohide"

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,67 +1,103 @@
 "use strict";
+
 import * as vscode from "vscode";
-import { TextEditorSelectionChangeKind } from "vscode"
+import { TextEditorSelectionChangeKind } from "vscode";
 
 export function activate(context: vscode.ExtensionContext) {
+    const initialConfig = vscode.workspace.getConfiguration("autoHide");
 
-    if (vscode.workspace.getConfiguration("autoHide").hideOnOpen) {
-        vscode.commands.executeCommand("workbench.action.closePanel");
-        vscode.commands.executeCommand("workbench.action.closeSidebar");
-        vscode.commands.executeCommand("workbench.action.closeAuxiliaryBar");
-    };
+    if (initialConfig.hideOnOpen) {
+        if (initialConfig.autoHideReferences) {
+            vscode.commands.executeCommand("closeReferenceSearch");
+        }
+
+        if (initialConfig.autoHidePanel) {
+            vscode.commands.executeCommand("workbench.action.closePanel");
+        }
+
+        if (initialConfig.autoHideSideBar) {
+            vscode.commands.executeCommand("workbench.action.closeSidebar");
+        }
+
+        if (initialConfig.autoHideAuxiliaryBar) {
+            vscode.commands.executeCommand("workbench.action.closeAuxiliaryBar");
+        }
+    }
 
     vscode.window.onDidChangeTextEditorSelection(selection => {
-        let config = vscode.workspace.getConfiguration("autoHide");
-        let path = vscode.window.activeTextEditor.document.fileName;
-        let pathIsFile = path.includes(".") || path.includes("\\") || path.includes("/");
-        let scheme = selection.textEditor.document.uri.scheme
+        const config = vscode.workspace.getConfiguration("autoHide");
+        const path = vscode.window.activeTextEditor.document.fileName;
+        const pathIsFile = path.includes(".") || path.includes("\\") || path.includes("/");
+        const scheme = selection.textEditor.document.uri.scheme;
 
-        if (selection.kind != TextEditorSelectionChangeKind.Mouse // selection was not from a click
-            || selection.selections.length != 1                   // no selections or multiselections
-            || selection.selections.find(a=>a.isEmpty) == null    // multiselections
-            || !pathIsFile                                        // The debug window editor
-            || scheme == "output" ) {                             // The output window
+        if (
+            selection.kind != TextEditorSelectionChangeKind.Mouse || // selection was not from a click
+            selection.selections.length != 1 ||                      // no selections or multiselections
+            selection.selections.find(a => a.isEmpty) == null ||     // multiselections
+            !pathIsFile ||                                           // The debug window editor
+            scheme == "output"                                       // The output window
+        ) {
             return;
-        } else {
-            if (config.autoHideReferences) {
-                vscode.commands.executeCommand("closeReferenceSearch");
+        }
+
+        if (config.autoHideReferences) {
+            vscode.commands.executeCommand("closeReferenceSearch");
+        }
+
+        setTimeout(function () {
+            if (config.autoHidePanel) {
+                vscode.commands.executeCommand("workbench.action.closePanel");
             }
+        }, config.panelDelay);
 
-            setTimeout(function() {
-                if (config.autoHidePanel) {
-                    vscode.commands.executeCommand("workbench.action.closePanel");
-                }
-            }, config.panelDelay);
+        setTimeout(function () {
+            if (config.autoHideSideBar) {
+                vscode.commands.executeCommand("workbench.action.closeSidebar");
+            }
+        }, config.sideBarDelay);
 
-            setTimeout(function() {
-                if (config.autoHideSideBar) {
-                    vscode.commands.executeCommand("workbench.action.closeSidebar");
-                }
-            }, config.sideBarDelay);
-
-            setTimeout(function() {
-                if (config.autoHideAuxiliaryBar) {
-                    vscode.commands.executeCommand("workbench.action.closeAuxiliaryBar");
-                }
-            }, config.sideBarDelay);
-        };
+        setTimeout(function () {
+            if (config.autoHideAuxiliaryBar) {
+                vscode.commands.executeCommand("workbench.action.closeAuxiliaryBar");
+            }
+        }, config.sideBarDelay);
     });
 
     context.subscriptions.push(
-        vscode.commands.registerCommand("autoHide.toggleHidePanel", async() => {
+        vscode.commands.registerCommand("autoHide.toggleHidePanel", async () => {
             let config = vscode.workspace.getConfiguration("autoHide");
-            await config.update("autoHidePanel", !config.autoHidePanel, vscode.ConfigurationTarget.Workspace);
-        }));
+            await config.update(
+                "autoHidePanel",
+                !config.autoHidePanel,
+                vscode.ConfigurationTarget.Workspace
+            );
+        })
+    );
+
     context.subscriptions.push(
-        vscode.commands.registerCommand("autoHide.toggleHideSideBar", async() => {
+        vscode.commands.registerCommand("autoHide.toggleHideSideBar", async () => {
             let config = vscode.workspace.getConfiguration("autoHide");
-            await config.update("autoHideSideBar", !config.autoHideSideBar, vscode.ConfigurationTarget.Workspace);
-        }));
+            await config.update(
+                "autoHideSideBar",
+                !config.autoHideSideBar,
+                vscode.ConfigurationTarget.Workspace
+            );
+        })
+    );
+
     context.subscriptions.push(
-        vscode.commands.registerCommand("autoHide.toggleHideAuxiliaryBar", async() => {
-            let config = vscode.workspace.getConfiguration("autoHide");
-            await config.update("autoHideAuxiliaryBar", !config.autoHideAuxiliaryBar, vscode.ConfigurationTarget.Workspace);
-        }));
+        vscode.commands.registerCommand(
+            "autoHide.toggleHideAuxiliaryBar",
+            async () => {
+                let config = vscode.workspace.getConfiguration("autoHide");
+                await config.update(
+                    "autoHideAuxiliaryBar",
+                    !config.autoHideAuxiliaryBar,
+                    vscode.ConfigurationTarget.Workspace
+                );
+            }
+        )
+    );
 }
 
-export function deactivate() {}
+export function deactivate() { }


### PR DESCRIPTION
Extension closes panels on startup regardless of the settings. Added settings check before taking actions on startup.